### PR TITLE
Added information on another dimmer library (my own).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Here the comparison against 2 similar and popular libraries:
 | Control *effective* delivered power  | yes, dynamic calculation                     | no                                                   | yes, static lookup table  | no |
 | Predefined effects           | no                                           | yes, automatic fade to new value                    | yes, swipe effect                 | no |
 | Optional zero-crossing mode | no                                           | no                                                   | yes                               | no |
-| Time resolution                         | 1us (2)                                    | 1/100 of semi-period energy                            | 1/100 of semi-period length             | 0.5 us |
+| Time resolution                         | 1us (2)                                    | 1/100 of semi-period energy                            | 1/100 of semi-period length             | 0.5us |
 | Smart interrupt management         | yes, automatically activated only if needed  | no                                                   | no                                | no |
 | Number of interrupts per semi-period (1)         | number of instantiated dimmers + 1  | 100                                                   | 100                                | 3 |
 

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ This brief overview gives a glimpse of the variety of properties to consider whi
 
 Here the comparison against 2 similar and popular libraries:
 
-|                                    | Dimmable Light for Arduino                            | [RobotDynOfficial/<br>RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                            | [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                          | [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
+|                                    | Dimmable Light for Arduino                            | [RobotDynOfficial/<br>RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                            | [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                          | [AJMansfield/<br>TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
 |----------------------------------- |--------------------------------------------- |----------------------------------------------------- |---------------------------------- |---------------------------------- |
 | Multiple dimmers                   | yes                                          | yes                                                  | yes                               | 2 |
 | Supported frequencies                    | 50/60Hz                                 | 50Hz                                            | 50/60Hz                         | 50/60Hz |

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ This brief overview gives a glimpse of the variety of properties to consider whi
 4. Control the load by 2 measurement unit: gate activation time or linearized relative power
 5. Documented parameters to finely tune the library on your hardware and requirements
 
-Here the comparison against 2 similar and popular libraries:
+Here the comparison against 3 similar and popular libraries:
 
 |                                    | Dimmable Light for Arduino                            | [RobotDynOfficial/<br>RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                            | [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                          | [AJMansfield/<br>TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
 |----------------------------------- |--------------------------------------------- |----------------------------------------------------- |---------------------------------- |---------------------------------- |

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ This brief overview gives a glimpse of the variety of properties to consider whi
 
 Here the comparison against 2 similar and popular libraries:
 
-|                                    | Dimmable Light for Arduino                            | [RobotDynOfficial/RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                            | [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                          | [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
+|                                    | Dimmable Light for Arduino                            | [RobotDynOfficial/<br>RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                            | [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                          | [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
 |----------------------------------- |--------------------------------------------- |----------------------------------------------------- |---------------------------------- |---------------------------------- |
 | Multiple dimmers                   | yes                                          | yes                                                  | yes                               | 2 |
 | Supported frequencies                    | 50/60Hz                                 | 50Hz                                            | 50/60Hz                         | 50/60Hz |

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Here the comparison against 2 similar and popular libraries:
 | Control *effective* delivered power  | yes, dynamic calculation                     | no                                                   | yes, static lookup table  | no |
 | Predefined effects           | no                                           | yes, automatic fade to new value                    | yes, swipe effect                 | no |
 | Optional zero-crossing mode | no                                           | no                                                   | yes                               | no |
-| Time resolution                         | up to 1us                                    | 1/100 of semi-period energy                            | 1/100 of semi-period length             | 0.5 us |
+| Time resolution                         | 1us (2)                                    | 1/100 of semi-period energy                            | 1/100 of semi-period length             | 0.5 us |
 | Smart interrupt management         | yes, automatically activated only if needed  | no                                                   | no                                | no |
 | Number of interrupts per semi-period (1)         | number of instantiated dimmers + 1  | 100                                                   | 100                                | 3 |
 

--- a/readme.md
+++ b/readme.md
@@ -28,13 +28,13 @@ Here the comparison against 2 similar and popular libraries:
 |                                    | Dimmable Light for Arduino                            | [RobotDynOfficial/RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                            | [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                          | [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
 |----------------------------------- |--------------------------------------------- |----------------------------------------------------- |---------------------------------- |---------------------------------- |
 | Multiple dimmers                   | yes                                          | yes                                                  | yes                               | 2 |
-| Supported Frequencies                    | 50/60Hz                                 | 50Hz                                            | 50/60Hz                         | 50/60Hz |
-| Supported architecture             | AVR, SAMD, ESP8266, ESP32                    | AVR, SAMD, ESP8266, ESP32, STM32F1, STM32F4, SAM  | AVR                               | AVR |
+| Supported frequencies                    | 50/60Hz                                 | 50Hz                                            | 50/60Hz                         | 50/60Hz |
+| Supported architectures             | AVR, SAMD, ESP8266, ESP32                    | AVR, SAMD, ESP8266, ESP32, STM32F1, STM32F4, SAM  | AVR                               | AVR |
 | Control *effective* delivered power  | yes, dynamic calculation                     | no                                                   | yes, static lookup table  | no |
-| Embedded automations           | no                                           | yes, automatic fade to new value                    | yes, swipe effect                 | no |
+| Predefined effects           | no                                           | yes, automatic fade to new value                    | yes, swipe effect                 | no |
 | Optional zero-crossing mode | no                                           | no                                                   | yes                               | no |
-| Resolution                         | up to 1us                                    | 1/100 of semi-period energy                            | 1/100 of semi-period length             | 0.5 us |
-| Smart Interrupt Management         | yes, automatically activated only if needed  | no                                                   | no                                | no |
+| Time resolution                         | up to 1us                                    | 1/100 of semi-period energy                            | 1/100 of semi-period length             | 0.5 us |
+| Smart interrupt management         | yes, automatically activated only if needed  | no                                                   | no                                | no |
 | Number of interrupts per semi-period (1)         | number of instantiated dimmers + 1  | 100                                                   | 100                                | 3 |
 
 (1) In the worst case, with default settings

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ The main features of this library:
 
 Here a complete comparison among the most similar libraries:
 
-|                                   	| Dimmable Light for Arduino                           	| [RobotDynOfficial/RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                           	| [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                         	| [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer)
+|                                   	| Dimmable Light for Arduino                           	| [RobotDynOfficial/RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                           	| [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                         	| [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer) |
 |-----------------------------------	|---------------------------------------------	|-----------------------------------------------------	|----------------------------------	|----------------------------------	|
 | Multiple dimmers                  	| yes                                         	| yes                                                 	| yes                              	| 2 |
 | Supported Frequencies                   	| 50/60Hz                                	| 50Hz                                           	| 50/60Hz                        	| 50/60Hz |

--- a/readme.md
+++ b/readme.md
@@ -11,17 +11,17 @@ The main features of this library:
 
 Here a complete comparison among the most similar libraries:
 
-|                                   	| Dimmable Light for Arduino                           	| [RobotDynOfficial/RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                           	| [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                         	|
-|-----------------------------------	|---------------------------------------------	|-----------------------------------------------------	|----------------------------------	|
-| Multiple dimmers                  	| yes                                         	| yes                                                 	| yes                              	|
-| Supported Frequencies                   	| 50/60Hz                                	| 50Hz                                           	| 50/60Hz                        	|
-| Supported architecture            	| AVR, SAMD, ESP8266, ESP32                   	| AVR, SAMD, ESP8266, ESP32, STM32F1, STM32F4, SAM 	| AVR                              	|
-| Control *effective* delivered power 	| yes, dynamic calculation                    	| no                                                  	| yes, static lookup table 	|
-| Embedded automations          	| no                                          	| yes, automatic fade to new value                   	| yes, swipe effect                	|
-| Optional zero-crossing mode | no                                          	| no                                                  	| yes                              	|
-| Resolution                        	| up to 1us                                   	| 1/100 of semi-period energy                           	| 1/100 of semi-period length            	|
-| Smart Interrupt Management        	| yes, automatically activated only if needed 	| no                                                  	| no                               	|
-| Number of interrupts per semi-period (1)        	| number of instantiated dimmers + 1 	| 100                                                  	| 100                               	|
+|                                   	| Dimmable Light for Arduino                           	| [RobotDynOfficial/RDBDimmer](https://github.com/RobotDynOfficial/RBDDimmer)                                           	| [circuitar/Dimmer](https://github.com/circuitar/Dimmer)                         	| [AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer)
+|-----------------------------------	|---------------------------------------------	|-----------------------------------------------------	|----------------------------------	|----------------------------------	|
+| Multiple dimmers                  	| yes                                         	| yes                                                 	| yes                              	| 2 |
+| Supported Frequencies                   	| 50/60Hz                                	| 50Hz                                           	| 50/60Hz                        	| 50/60Hz |
+| Supported architecture            	| AVR, SAMD, ESP8266, ESP32                   	| AVR, SAMD, ESP8266, ESP32, STM32F1, STM32F4, SAM 	| AVR                              	| AVR |
+| Control *effective* delivered power 	| yes, dynamic calculation                    	| no                                                  	| yes, static lookup table 	| no |
+| Embedded automations          	| no                                          	| yes, automatic fade to new value                   	| yes, swipe effect                	| no |
+| Optional zero-crossing mode | no                                          	| no                                                  	| yes                              	| no |
+| Resolution                        	| up to 1us                                   	| 1/100 of semi-period energy                           	| 1/100 of semi-period length            	| 0.5 us |
+| Smart Interrupt Management        	| yes, automatically activated only if needed 	| no                                                  	| no                               	| no |
+| Number of interrupts per semi-period (1)        	| number of instantiated dimmers + 1 	| 100                                                  	| 100                               	| 3 |
 
 (1) In the worst case, with default settings 
 

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ Here the comparison against 2 similar and popular libraries:
 | Smart interrupt management         | yes, automatically activated only if needed  | no                                                   | no                                | no |
 | Number of interrupts per semi-period (1)         | number of instantiated dimmers + 1  | 100                                                   | 100                                | 3 |
 
-(1) In the worst case, with default settings
+(1) In the worst case, with default settings\
 (2) If the hardware timer allows it, otherwise it will be lower
 
 ## Installation


### PR DESCRIPTION
[AJMansfield/TriacDimmer](https://github.com/AJMansfield/TriacDimmer) is another phase-delay triac dimmer control library, developed by myself about 4 years ago.
While it's a lot less flexible in how it can be used, it takes advantage of additional features of the Atmel timers not used by other libraries to provide much more robust guarantees about timing accuracy, while allowing application code somewhat more freedom in implementing application functionality in ways that would conflict with other dimmer libraries.

In terms of raw specifications, this library allows a up to a half-microsecond resolution (assuming a 16 MHz system clock), and guarantees that the commanded phase offsets and pulse durations will be met with a tolerance of ± 0.5 µs with no compensation or tuning for variable code execution time.
These timing guarantees are met even if application code needs to make use of  `cli()` to guard other timing-sensitive bit-bang operations, or has other interrupts that must be serviced at a higher priority, without making any compromises on accuracy or precision as long as the longest interrupt-excluded section always completes faster than the shortest commanded pulse duration or phase offset.
Outside that regime, there are additional safeguards that allow the library to continue to behave reasonably (for certain definitions of reasonable) in situations where that limit is exceeded by a small amount, and to quickly recover and return to normal operation once back in the preferred operating regime.

