### PR TITLE
Fix compile errors and warnings

### DIFF
--- a/src/dimmable_light_manager.h
+++ b/src/dimmable_light_manager.h
@@ -30,6 +30,7 @@
 #include <map>
 #endif
 
+#include <string>
 #include <dimmable_light.h>
 
 /**

--- a/src/hw_timer_esp8266.c
+++ b/src/hw_timer_esp8266.c
@@ -29,9 +29,9 @@ in non autoload mode:
                         10 ~ 0x7fffff;
 * Returns      : NONE
 *******************************************************************************/
-void IRAM_ATTR hw_timer_arm(u32 val)
+void HW_TIMER_IRAM_ATTR hw_timer_arm(u32 val)
 {
-    TIMER_REG_WRITE(FRC1_LOAD_ADDRESS, US_TO_RTC_TIMER_TICKS(val));
+    HW_TIMER_REG_WRITE(FRC1_LOAD_ADDRESS, US_TO_RTC_TIMER_TICKS(val));
 }
 
 static void (* user_hw_timer_cb)(void) = NULL;
@@ -42,12 +42,12 @@ static void (* user_hw_timer_cb)(void) = NULL;
                         timer callback function,
 * Returns      : NONE
 *******************************************************************************/
-void IRAM_ATTR hw_timer_set_func(void (* user_hw_timer_cb_set)(void))
+void HW_TIMER_IRAM_ATTR hw_timer_set_func(void (* user_hw_timer_cb_set)(void))
 {
     user_hw_timer_cb = user_hw_timer_cb_set;
 }
 
-static IRAM_ATTR void  hw_timer_isr_cb(void)
+static HW_TIMER_IRAM_ATTR void  hw_timer_isr_cb(void)
 {
     if (user_hw_timer_cb != NULL) {
         (*(user_hw_timer_cb))();
@@ -66,13 +66,13 @@ u8 req:
                         1,  autoload mode,
 * Returns      : NONE
 *******************************************************************************/
-void IRAM_ATTR hw_timer_init(FRC1_TIMER_SOURCE_TYPE source_type, u8 req)
+void HW_TIMER_IRAM_ATTR hw_timer_init(FRC1_TIMER_SOURCE_TYPE source_type, u8 req)
 {
     if (req == 1) {
-        TIMER_REG_WRITE(FRC1_CTRL_ADDRESS,
+        HW_TIMER_REG_WRITE(FRC1_CTRL_ADDRESS,
                       FRC1_AUTO_LOAD | DIVDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
     } else {
-        TIMER_REG_WRITE(FRC1_CTRL_ADDRESS,
+        HW_TIMER_REG_WRITE(FRC1_CTRL_ADDRESS,
                       DIVDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
     }
 

--- a/src/hw_timer_esp8266.c
+++ b/src/hw_timer_esp8266.c
@@ -29,9 +29,9 @@ in non autoload mode:
                         10 ~ 0x7fffff;
 * Returns      : NONE
 *******************************************************************************/
-void ICACHE_RAM_ATTR hw_timer_arm(u32 val)
+void IRAM_ATTR hw_timer_arm(u32 val)
 {
-    RTC_REG_WRITE(FRC1_LOAD_ADDRESS, US_TO_RTC_TIMER_TICKS(val));
+    TIMER_REG_WRITE(FRC1_LOAD_ADDRESS, US_TO_RTC_TIMER_TICKS(val));
 }
 
 static void (* user_hw_timer_cb)(void) = NULL;
@@ -42,12 +42,12 @@ static void (* user_hw_timer_cb)(void) = NULL;
                         timer callback function,
 * Returns      : NONE
 *******************************************************************************/
-void ICACHE_RAM_ATTR hw_timer_set_func(void (* user_hw_timer_cb_set)(void))
+void IRAM_ATTR hw_timer_set_func(void (* user_hw_timer_cb_set)(void))
 {
     user_hw_timer_cb = user_hw_timer_cb_set;
 }
 
-static ICACHE_RAM_ATTR void  hw_timer_isr_cb(void)
+static IRAM_ATTR void  hw_timer_isr_cb(void)
 {
     if (user_hw_timer_cb != NULL) {
         (*(user_hw_timer_cb))();
@@ -66,13 +66,13 @@ u8 req:
                         1,  autoload mode,
 * Returns      : NONE
 *******************************************************************************/
-void ICACHE_RAM_ATTR hw_timer_init(FRC1_TIMER_SOURCE_TYPE source_type, u8 req)
+void IRAM_ATTR hw_timer_init(FRC1_TIMER_SOURCE_TYPE source_type, u8 req)
 {
     if (req == 1) {
-        RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
+        TIMER_REG_WRITE(FRC1_CTRL_ADDRESS,
                       FRC1_AUTO_LOAD | DIVDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
     } else {
-        RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
+        TIMER_REG_WRITE(FRC1_CTRL_ADDRESS,
                       DIVDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
     }
 

--- a/src/hw_timer_esp8266.h
+++ b/src/hw_timer_esp8266.h
@@ -17,6 +17,18 @@ extern "C" {
 #define FRC1_ENABLE_TIMER  BIT7
 #define FRC1_AUTO_LOAD  BIT6
 
+#ifdef IRAM_ATTR
+    #define HW_TIMER_IRAM_ATTR IRAM_ATTR
+#else
+    #define HW_TIMER_IRAM_ATTR ICACHE_RAM_ATTR
+#endif
+
+#ifdef TIMER_REG_WRITE
+    #define HW_TIMER_REG_WRITE TIMER_REG_WRITE
+#else
+    #define HW_TIMER_REG_WRITE RTC_REG_WRITE
+#endif
+
 //TIMER PREDIVED MODE
 typedef enum {
     DIVDED_BY_1 = 0,    //timer clock

--- a/src/thyristor.cpp
+++ b/src/thyristor.cpp
@@ -130,7 +130,7 @@ static uint8_t thyristorManaged = 0;
 static uint8_t alwaysOnCounter = 0;
 
 #if defined(ARDUINO_ARCH_ESP8266)
-void ICACHE_RAM_ATTR turn_off_gates_int(){
+void IRAM_ATTR turn_off_gates_int(){
 #elif defined(ARDUINO_ARCH_ESP32)
 void IRAM_ATTR turn_off_gates_int(){
 #else
@@ -147,7 +147,7 @@ void turn_off_gates_int(){
  * lamps with different at least a different delay value).
  */
 #if defined(ARDUINO_ARCH_ESP8266)
-void ICACHE_RAM_ATTR activate_thyristors(){
+void IRAM_ATTR activate_thyristors(){
 #elif defined(ARDUINO_ARCH_ESP32)
 void IRAM_ATTR activate_thyristors(){
 #else
@@ -253,7 +253,7 @@ static uint32_t total = 0;
 #endif
 
 #if defined(ARDUINO_ARCH_ESP8266)
-void ICACHE_RAM_ATTR zero_cross_int(){
+void IRAM_ATTR zero_cross_int(){
 #elif defined(ARDUINO_ARCH_ESP32)
 void IRAM_ATTR zero_cross_int(){
 #else

--- a/src/thyristor.cpp
+++ b/src/thyristor.cpp
@@ -130,7 +130,7 @@ static uint8_t thyristorManaged = 0;
 static uint8_t alwaysOnCounter = 0;
 
 #if defined(ARDUINO_ARCH_ESP8266)
-void IRAM_ATTR turn_off_gates_int(){
+void HW_TIMER_IRAM_ATTR turn_off_gates_int(){
 #elif defined(ARDUINO_ARCH_ESP32)
 void IRAM_ATTR turn_off_gates_int(){
 #else
@@ -147,7 +147,7 @@ void turn_off_gates_int(){
  * lamps with different at least a different delay value).
  */
 #if defined(ARDUINO_ARCH_ESP8266)
-void IRAM_ATTR activate_thyristors(){
+void HW_TIMER_IRAM_ATTR activate_thyristors(){
 #elif defined(ARDUINO_ARCH_ESP32)
 void IRAM_ATTR activate_thyristors(){
 #else
@@ -253,7 +253,7 @@ static uint32_t total = 0;
 #endif
 
 #if defined(ARDUINO_ARCH_ESP8266)
-void IRAM_ATTR zero_cross_int(){
+void HW_TIMER_IRAM_ATTR zero_cross_int(){
 #elif defined(ARDUINO_ARCH_ESP32)
 void IRAM_ATTR zero_cross_int(){
 #else


### PR DESCRIPTION
In `src/dimmable_light_manager.h` added import of `string` to fix compile error
Replaced `ICACHE_RAM_ATTR` with `IRAM_ATTR` because of deprecation
Replaced `RTC_REG_WRITE` with `TIMER_REG_WRITE` because of deprecation
