### PR TITLE
Add Pico RP2040 (non-mbed) support

### DIFF
--- a/.github/workflows/LibraryBuild.yml
+++ b/.github/workflows/LibraryBuild.yml
@@ -26,9 +26,9 @@ jobs:
 
         # define each specific configuration
         include:
-          
+
           # if the current configuration contains the parameter "config-name" and it is equal to "esp8266-v2",
-          # add the following parameters to this configuration. If board-type is never matched, 
+          # add the following parameters to this configuration. If board-type is never matched,
           # a new singular configuration is created
           - config-name: esp8266-v2
             platform-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
@@ -63,6 +63,12 @@ jobs:
           - config-name: arduino-nano-33-iot
             arduino-platform: arduino:samd@1.8.13
             arduino-boards-fqbn: arduino:samd:nano_33_iot
+            sketches-exclude: 3_dimmable_light_5_light, 5_dimmable_manager_n_lights
+
+          - config-name: rpi-pico
+            platform-url: https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json
+            arduino-platform: rp2040:rp2040@3.6.0
+            arduino-boards-fqbn: rp2040:rp2040:rpipico
             sketches-exclude: 3_dimmable_light_5_light, 5_dimmable_manager_n_lights
 
       # Do not cancel all jobs / architectures if one job fails

--- a/examples/4_lights_manager/4_lights_manager.ino
+++ b/examples/4_lights_manager/4_lights_manager.ino
@@ -19,6 +19,9 @@ const int pins[N] = { 3, 4, 5 };
 #elif defined(ARDUINO_ARCH_SAMD)
 const int syncPin = 2;
 const int pins[N] = { 3, 4, 5 };
+#elif (defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED))
+const int syncPin = 2;
+const int pins[N] = { 3, 4, 5 };
 #endif
 
 DimmableLightManager dlm;

--- a/examples/6_8_lights_effects/effect.cpp
+++ b/examples/6_8_lights_effects/effect.cpp
@@ -26,6 +26,8 @@ extern DimmableLightLinearized
 lights[N_LIGHTS] = { { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 } };
 #elif defined(ARDUINO_ARCH_SAMD)
 lights[N_LIGHTS] = { { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 } };
+#elif (defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED))
+lights[N_LIGHTS] = { { 3 }, { 4 }, { 5 }, { 6 }, { 7 }, { 8 }, { 9 }, { 10 } };
 #endif
 
 /**

--- a/examples/6_8_lights_effects/effect.h
+++ b/examples/6_8_lights_effects/effect.h
@@ -20,6 +20,8 @@ const int syncPin = 23;
 const int syncPin = 2;
 #elif defined(ARDUINO_ARCH_SAMD)
 const int syncPin = 2;
+#elif (defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED))
+const int syncPin = 2;
 #endif
 
 #if defined(RAW_VALUES)

--- a/library.json
+++ b/library.json
@@ -27,7 +27,8 @@
     "espressif8266",
     "espressif32",
     "atmelavr",
-    "atmelsam"
+    "atmelsam",
+    "raspberrypi"
   ],
   "dependencies": [
     {

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=This library allows to easily control dimmers (also known as thyristors
 paragraph=This library was born to control dimmable light bulbs, but actually dimmers are fully compatible with other AC loads like electrical heaters and motors (be aware of what you are doing!). Actually it works on ESP8266, ESP32, AVR and SAMD.
 category=Device Control
 url=https://github.com/fabianoriccardi/dimmable-light
-architectures=esp8266,esp32,avr,samd
+architectures=esp8266,esp32,avr,samd,rp2040
 depends=ArduinoSTL

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,7 @@ framework = arduino
 platform = atmelavr@4.2.0
 board = uno
 framework = arduino
-lib_deps = 
+lib_deps =
     ${env.lib_deps}
     mike-matera/ArduinoSTL@^1.3.3
 upload_speed = 115200
@@ -40,7 +40,7 @@ upload_speed = 115200
 platform = atmelavr@4.2.0
 board = megaatmega2560
 framework = arduino
-lib_deps = 
+lib_deps =
     ${env.lib_deps}
     mike-matera/ArduinoSTL@^1.3.3
 upload_speed = 115200
@@ -49,3 +49,9 @@ upload_speed = 115200
 platform = atmelsam@8.2.0
 board = nano_33_iot
 framework = arduino
+
+[env:rpipico]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = pico
+framework = arduino
+board_build.core = earlephilhower

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ This brief overview gives a glimpse of the variety of properties to consider whi
 ## Features
 
 1. Control multiple thyristors using a single hardware timer
-2. Compatible with multiple platforms (ESP8266/ESP32/AVR/SAMD)
+2. Compatible with multiple platforms (ESP8266/ESP32/AVR/SAMD/RP2040)
 3. Interrupt optimization (trigger interrupts only if necessary, no periodic interrupt)
 4. Control the load by 2 measurement unit: gate activation time or linearized relative power
 5. Documented parameters to finely tune the library on your hardware and requirements
@@ -29,7 +29,7 @@ Here the comparison against 2 similar and popular libraries:
 |------------------------------------------|---------------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------|
 | Multiple dimmers                         | yes                                         | yes                                                                         | yes                                                     |
 | Supported Frequencies                    | 50/60Hz                                     | 50Hz                                                                        | 50/60Hz                                                 |
-| Supported architectures                  | AVR, SAMD, ESP8266, ESP32                   | AVR, SAMD, ESP8266, ESP32, STM32F1, STM32F4, SAM                            | AVR                                                     |
+| Supported architectures                  | AVR, SAMD, ESP8266, ESP32, RP2040           | AVR, SAMD, ESP8266, ESP32, STM32F1, STM32F4, SAM                            | AVR                                                     |
 | Control *effective* delivered power      | yes, dynamic calculation                    | no                                                                          | yes, static lookup table                                |
 | Predefined effects                       | no                                          | yes, automatic fade to new value                                            | yes, swipe effect                                       |
 | Optional zero-crossing mode              | no                                          | no                                                                          | yes                                                     |

--- a/src/dimmable_light_manager.cpp
+++ b/src/dimmable_light_manager.cpp
@@ -21,7 +21,7 @@
 
 bool DimmableLightManager::add(String lightName, uint8_t pin) {
   const char* temp = lightName.c_str();
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040)
   std::unordered_map<std::string, DimmableLight*>::const_iterator it = dla.find(temp);
 #elif defined(AVR)
   std::map<std::string, DimmableLight*>::const_iterator it = dla.find(temp);
@@ -37,7 +37,7 @@ bool DimmableLightManager::add(String lightName, uint8_t pin) {
 
 DimmableLight* DimmableLightManager::get(String lightName) {
   const char* temp = lightName.c_str();
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040)
   std::unordered_map<std::string, DimmableLight*>::const_iterator it = dla.find(temp);
 #elif defined(AVR)
   std::map<std::string, DimmableLight*>::const_iterator it = dla.find(temp);
@@ -50,7 +50,7 @@ DimmableLight* DimmableLightManager::get(String lightName) {
 }
 
 std::pair<String, DimmableLight*> DimmableLightManager::get() {
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040)
   static std::unordered_map<std::string, DimmableLight*>::const_iterator it = dla.begin();
 #elif defined(AVR)
   static std::map<std::string, DimmableLight*>::const_iterator it = dla.begin();

--- a/src/dimmable_light_manager.h
+++ b/src/dimmable_light_manager.h
@@ -22,7 +22,7 @@
 
 #include "dimmable_light.h"
 
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040)
 // Unfortunately Arduino defines max/min macros, those create conflicts with the one
 // defined by C++/STL environment
 #undef max
@@ -68,7 +68,7 @@ public:
   }
 
 private:
-#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD)
+#if defined(ESP8266) || defined(ESP32) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040)
   std::unordered_map<std::string, DimmableLight*> dla;
 #elif defined(AVR)
   std::map<std::string, DimmableLight*> dla;

--- a/src/hw_timer_pico.cpp
+++ b/src/hw_timer_pico.cpp
@@ -1,22 +1,22 @@
-/***************************************************************************
- *   This file is part of Dimmable Light for Arduino, a library to         *
- *   control dimmers.                                                      *
- *                                                                         *
- *   Copyright (C) 2018-2022  Fabiano Riccardi                             *
- *                                                                         *
- *   Dimmable Light for Arduino is free software; you can redistribute     *
- *   it and/or modify it under the terms of the GNU Lesser General Public  *
- *   License as published by the Free Software Foundation; either          *
- *   version 2.1 of the License, or (at your option) any later version.    *
- *                                                                         *
- *   This library is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
- *   Lesser General Public License for more details.                       *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
- ***************************************************************************/
+/******************************************************************************
+ *  This file is part of Dimmable Light for Arduino, a library to control     *
+ *  dimmers.                                                                  *
+ *                                                                            *
+ *  Copyright (C) 2018-2023  Fabiano Riccardi                                 *
+ *                                                                            *
+ *  Dimmable Light for Arduino is free software; you can redistribute         *
+ *  it and/or modify it under the terms of the GNU Lesser General Public      *
+ *  License as published by the Free Software Foundation; either              *
+ *  version 2.1 of the License, or (at your option) any later version.        *
+ *                                                                            *
+ *  This library is distributed in the hope that it will be useful,           *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU          *
+ *  Lesser General Public License for more details.                           *
+ *                                                                            *
+ *  You should have received a copy of the GNU Lesser General Public License  *
+ *  along with this library; if not, see <http://www.gnu.org/licenses/>.      *
+ ******************************************************************************/
 
 #if defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED)
 

--- a/src/hw_timer_pico.cpp
+++ b/src/hw_timer_pico.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *   This file is part of Dimmable Light for Arduino, a library to         *
+ *   control dimmers.                                                      *
+ *                                                                         *
+ *   Copyright (C) 2018-2022  Fabiano Riccardi                             *
+ *                                                                         *
+ *   Dimmable Light for Arduino is free software; you can redistribute     *
+ *   it and/or modify it under the terms of the GNU Lesser General Public  *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#if defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED)
+
+#include "hw_timer_pico.h"
+#include <Arduino.h>
+
+static void (*timer_callback)() = nullptr;
+static alarm_id_t alarm_id;
+static alarm_pool_t *alarm_pool;
+
+void timerBegin() {
+  alarm_pool = alarm_pool_get_default();
+}
+
+void timerSetCallback(void (*callback)()) {
+  timer_callback = callback;
+}
+
+void timerStart(uint64_t t) {
+  if (alarm_id) {
+    cancel_alarm(alarm_id);
+    alarm_id = 0;
+  }
+
+  alarm_id = alarm_pool_add_alarm_in_us(
+    alarm_pool, t,
+    [](alarm_id_t, void *) -> int64_t {
+      if (timer_callback != nullptr) { timer_callback(); }
+      alarm_id = 0;
+      return 0;  // Do not reschedule alarm
+    },
+    NULL, true);
+}
+
+#endif  // END ARDUINO_ARCH_RP2040

--- a/src/hw_timer_pico.h
+++ b/src/hw_timer_pico.h
@@ -1,22 +1,22 @@
-/***************************************************************************
- *   This file is part of Dimmable Light for Arduino, a library to         *
- *   control dimmers.                                                      *
- *                                                                         *
- *   Copyright (C) 2018-2022  Fabiano Riccardi                             *
- *                                                                         *
- *   Dimmable Light for Arduino is free software; you can redistribute     *
- *   it and/or modify it under the terms of the GNU Lesser General Public  *
- *   License as published by the Free Software Foundation; either          *
- *   version 2.1 of the License, or (at your option) any later version.    *
- *                                                                         *
- *   This library is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
- *   Lesser General Public License for more details.                       *
- *                                                                         *
- *   You should have received a copy of the GNU General Public License     *
- *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
- ***************************************************************************/
+/******************************************************************************
+ *  This file is part of Dimmable Light for Arduino, a library to control     *
+ *  dimmers.                                                                  *
+ *                                                                            *
+ *  Copyright (C) 2018-2023  Fabiano Riccardi                                 *
+ *                                                                            *
+ *  Dimmable Light for Arduino is free software; you can redistribute         *
+ *  it and/or modify it under the terms of the GNU Lesser General Public      *
+ *  License as published by the Free Software Foundation; either              *
+ *  version 2.1 of the License, or (at your option) any later version.        *
+ *                                                                            *
+ *  This library is distributed in the hope that it will be useful,           *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU          *
+ *  Lesser General Public License for more details.                           *
+ *                                                                            *
+ *  You should have received a copy of the GNU Lesser General Public License  *
+ *  along with this library; if not, see <http://www.gnu.org/licenses/>.      *
+ ******************************************************************************/
 
 #if defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED)
 

--- a/src/hw_timer_pico.h
+++ b/src/hw_timer_pico.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *   This file is part of Dimmable Light for Arduino, a library to         *
+ *   control dimmers.                                                      *
+ *                                                                         *
+ *   Copyright (C) 2018-2022  Fabiano Riccardi                             *
+ *                                                                         *
+ *   Dimmable Light for Arduino is free software; you can redistribute     *
+ *   it and/or modify it under the terms of the GNU Lesser General Public  *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#if defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED)
+
+#ifndef HW_TIMER_PICO_H
+#define HW_TIMER_PICO_H
+
+#include <stdint.h>
+
+/**
+ * Initialize the timer.
+ */
+void timerBegin();
+
+/**
+ * Set callback function on timer triggers
+ */
+void timerSetCallback(void (*callback)());
+
+/**
+ * Start the timer to trigger after the specified number of microseconds.
+ */
+void timerStart(uint64_t t);
+
+#endif  // HW_TIMER_PICO_H
+
+#endif  // ARDUINO_ARCH_RP2040

--- a/src/hw_timer_pico.h
+++ b/src/hw_timer_pico.h
@@ -2,7 +2,7 @@
  *  This file is part of Dimmable Light for Arduino, a library to control     *
  *  dimmers.                                                                  *
  *                                                                            *
- *  Copyright (C) 2018-2023  Fabiano Riccardi                                 *
+ *  Copyright (C) 2023  Adam Hoese                                            *
  *                                                                            *
  *  Dimmable Light for Arduino is free software; you can redistribute         *
  *  it and/or modify it under the terms of the GNU Lesser General Public      *


### PR DESCRIPTION
This adds support for RP2040 based boards such as the Pico and the Pico W using arduino-pico.
Note that this is distinctly different from the mbed-OS based platform which would have to be implemented separately.

I have tested this on a Pico W.

Github Actions related changes haven't been tested, only actually running the code on my board.